### PR TITLE
better `nix-indent-line`

### DIFF
--- a/nix-mode.el
+++ b/nix-mode.el
@@ -371,7 +371,7 @@ STRING-TYPE type of string based off of Emacs syntax table types"
     (when matching-indentation
       (if (save-excursion (beginning-of-line)
                           (skip-chars-forward "[:space:]")
-                          (looking-at "let\\|with\\|\\[\\|{"))
+                          (looking-at "let\\|with\\|\\[\\|{\\|("))
           (indent-line-to matching-indentation)
         (indent-line-to (+ tab-width matching-indentation)))
       t)))
@@ -491,7 +491,7 @@ The hook `nix-mode-hook' is run when Nix mode is started.
   ;; Recommended by nixpkgs manual: https://nixos.org/nixpkgs/manual/#sec-syntax
   (setq-local indent-tabs-mode nil)
   (setq-local tab-width 2)
-  (setq-local electric-indent-chars '(?\n ?{ ?} ?[ ?] ?= ?\;))
+  (setq-local electric-indent-chars '(?\n ?{ ?} ?[ ?] ?( ?)))
 
   ;; Font lock support.
   (setq-local font-lock-defaults '(nix-font-lock-keywords))

--- a/nix-mode.el
+++ b/nix-mode.el
@@ -412,10 +412,10 @@ STRING-TYPE type of string based off of Emacs syntax table types"
                                        )))))
 
    ;; dedent '}', ']', ')' 'in'
-   (nix-indent-to-backward-match)
+   ((nix-indent-to-backward-match))
 
    ;; indent between = and ; + 2, or to 2
-   (nix-indent-expression-start)
+   ((nix-indent-expression-start))
 
    ;; else
    (t

--- a/nix-mode.el
+++ b/nix-mode.el
@@ -371,7 +371,7 @@ STRING-TYPE type of string based off of Emacs syntax table types"
     (when matching-indentation
       (if (save-excursion (beginning-of-line) (looking-at "let\\|with\\|\\[\\|{"))
           (indent-line-to matching-indentation)
-        (indent-line-to (+ 2 matching-indentation)))
+        (indent-line-to (+ tab-width matching-indentation)))
       t)))
 
 (defun nix-indent-prev-level ()

--- a/nix-mode.el
+++ b/nix-mode.el
@@ -369,7 +369,9 @@ STRING-TYPE type of string based off of Emacs syntax table types"
   (let ((matching-indentation (save-excursion (when (nix-indent-find-BOL-expression-start)
                                                 (current-indentation)))))
     (when matching-indentation
-      (if (save-excursion (beginning-of-line) (looking-at "let\\|with\\|\\[\\|{"))
+      (if (save-excursion (beginning-of-line)
+                          (skip-chars-forward "[:space:]")
+                          (looking-at "let\\|with\\|\\[\\|{"))
           (indent-line-to matching-indentation)
         (indent-line-to (+ tab-width matching-indentation)))
       t)))
@@ -385,6 +387,7 @@ STRING-TYPE type of string based off of Emacs syntax table types"
 (defun nix-indent-line ()
   "Indent current line in a Nix expression."
   (interactive)
+  (let ((end-of-indentation (save-excursion
   (cond
 
    ;; comment
@@ -420,7 +423,10 @@ STRING-TYPE type of string based off of Emacs syntax table types"
    ;; else
    (t
       (indent-line-to (nix-indent-prev-level)))
-    ))
+   )
+  (point))))
+    (when (> end-of-indentation (point)) (goto-char end-of-indentation)))
+  )
 
 ;; Key maps
 
@@ -485,6 +491,7 @@ The hook `nix-mode-hook' is run when Nix mode is started.
   ;; Recommended by nixpkgs manual: https://nixos.org/nixpkgs/manual/#sec-syntax
   (setq-local indent-tabs-mode nil)
   (setq-local tab-width 2)
+  (setq-local electric-indent-chars '(?\n ?{ ?} ?[ ?] ?= ?\;))
 
   ;; Font lock support.
   (setq-local font-lock-defaults '(nix-font-lock-keywords))


### PR DESCRIPTION
Two rules for indentation:
1. lines starting with `}`, `]`, `)` or `in` get indented to the same level as their matching token.
2. any other lines get indented to the next level for their matching `=`, or 2, unless they start with `let`, `with`, `[`, `{` or `(`

These seem to work okay on simple nix files, and only take a few seconds (per line) on 2MB of attrsets. Let me know if you find any failure cases.