### PR TITLE
nix-repl.el: make it work with newer nix repl command

### DIFF
--- a/nix-repl.el
+++ b/nix-repl.el
@@ -14,9 +14,13 @@
   "nix-repl customizations"
   :group 'nix)
 
-(defcustom nix-repl-executable "nix-repl"
+(defcustom nix-repl-executable "nix"
   "Location of nix-repl command."
   :type 'string)
+
+(defcustom nix-repl-executable-args '("repl")
+  "Arguments to provide to nix-repl."
+  :type 'list)
 
 (define-derived-mode nix-repl-mode comint-mode "Nix-REPL"
   "Interactive prompt for Nix."
@@ -47,7 +51,10 @@
 
 (defun nix--make-repl-in-buffer (buffer)
   "Make Nix Repl in BUFFER."
-  (make-comint-in-buffer "Nix-REPL" buffer nix-repl-executable))
+  (apply
+   'make-comint-in-buffer
+   (append `("Nix-REPL" ,buffer ,nix-repl-executable nil)
+           nix-repl-executable-args)))
 
 (defun nix-get-completions (proc prefix)
   "Get Nix completions from Nix-repl process PROC and based off of PREFIX."


### PR DESCRIPTION
If you try to use `nix-repl` with recent Nix (with a builtin `nix repl` command), the process will die:

```
error: Nix database directory ‘/nix/var/nix/db’ is not writable: Permission denied

Process Nix-REPL exited abnormally with code 1
```

This makes it so that `M-x nix-repl` command uses `nix repl` by default.

For people stuck on older Nix, the existing behaviour can be restored by `(setq nix-repl-executable-args nil)` and `(setq nix-repl-executable "nix-repl")`.

This could probably be improved by parsing the output of `nix --version` and selecting a suitable command, but I'm not sure how best to do that.