### PR TITLE
Improve indentation robustness

### DIFF
--- a/nix-mode.el
+++ b/nix-mode.el
@@ -36,7 +36,7 @@ Valid functions for this are:
   :type 'function)
 
 (defcustom nix-mode-caps
-  '(" =[ \n]" "\(" "\{" "\\[" "\\bwith " "\\blet\\b" "\\binherit\\b")
+  '(" =[ \n]" "\(" "\{" "\\[" "\\bwith\\b" "\\blet\\b" "\\binherit\\b")
   "Regular expressions to consider expression caps."
   :group 'nix-mode
   :type '(repeat string))
@@ -390,7 +390,7 @@ STRING-TYPE type of string based off of Emacs syntax table types"
   "Return regexp for matching string quotes."
   (nix-mode-make-regexp nix-mode-quotes))
 
-(defun nix-mode-combined-regexp
+(defun nix-mode-combined-regexp ()
   "Return combined regexp for matching items of interest."
     (nix-mode-make-regexp (append nix-mode-caps
                                   nix-mode-ends

--- a/nix-mode.el
+++ b/nix-mode.el
@@ -414,7 +414,7 @@ STRING-TYPE type of string based off of Emacs syntax table types"
         (cond
          ((looking-at (nix-mode-quotes-regexp))
           ;; skip over strings entirely
-          (re-search-backward nix-mode-quotes-regexp nil t))
+          (re-search-backward (nix-mode-quotes-regexp) nil t))
          ((looking-at (nix-mode-ends-regexp))
           ;; count the matched end
           ;; this means we expect to find at least one more cap

--- a/nix-mode.el
+++ b/nix-mode.el
@@ -398,7 +398,7 @@ STRING-TYPE type of string based off of Emacs syntax table types"
 
 (defun nix-mode-search-backward ()
   "Search backward for items of interest regarding indentation."
-  (re-search-backward nix-mode-combined-regexp nil t))
+  (re-search-backward (nix-mode-combined-regexp) nil t))
 
 (defun nix-indent-expression-start ()
   (let* ((ends 0)


### PR DESCRIPTION
Improves indentation by covering more cases more often. It isn't perfect, but I've shopped it around and people seem to approve.

I defer to the code, which is heavily commented, for a deeper explanation of the technique. But in summary, the algorithm looks something like:

- Define what we consider to be expression `caps` and `ends` which we will count to track expression balance.
- Search backwards looking for caps, ends, or string quotes.
- When a quote is found, skip to the matching quote
- When an end is found, increase a counter of how many corresponding caps we expect to find
- When we find an unexpected cap, we know we found the expression that contains the line to indent
- Indent the line 1 x tab-width relative to the line of the containing expression.
- If we reached the top of the buffer perfectly balanced don't indent.

** Quirks
- the `=` sign in assignments must be couched by spaces
- there is seemingly no (easy) way to track function definitions/calls as they don't have parenthetical expression syntax like everything else does.
- probably slow on very very large files (you know the one)