### PR TITLE
Add function to indent things in blocks for nix-indent-line

### DIFF
--- a/nix-mode.el
+++ b/nix-mode.el
@@ -380,6 +380,39 @@ STRING-TYPE type of string based off of Emacs syntax table types"
                                     (current-indentation)))))
     (when matching-indentation (indent-line-to matching-indentation) t)))
 
+(defun nix-indent-first-line-in-block ()
+  "Indent the first line in a block."
+
+  (let ((matching-indentation (save-excursion
+                                ;; If we're on the first line of the buffer
+                                (if (= (line-number-at-pos) 1)
+                                    ;; Return that we want to ident to position 0 if we're on th
+                                    ;; first line. This fixes bad indent of things and avoid endless
+                                    ;; indent loop of tokens that would match below if we press tab
+                                    ;; on the first line and it happens to match any of the ones below.
+                                    0
+
+                                  ;; Go back to previous line that contain anything useful to check the
+                                  ;; contents of that line.
+                                  (beginning-of-line)
+                                  (skip-chars-backward "\n[:space:]")
+
+                                  ;; Grab the full string of the line before the one we're indenting
+                                  (let ((line (buffer-substring-no-properties (line-beginning-position) (line-end-position))))
+                                    ;; Then regex-match strings at the end of the line to detect if we need to indent the line after.
+                                    ;; We could probably add more things to look for here in the future.
+                                    (if (or (string-match "let$" line)
+                                            (string-match "import$" line)
+                                            (string-match "\\[$" line)
+                                            (string-match "=$" line)
+                                            (string-match "\($" line)
+                                            (string-match "\{$" line))
+
+                                        ;; If it matches any of the regexes above, grab the indent level
+                                        ;; of the line and add 2 to ident the line below this one.
+                                        (+ 2 (current-indentation))))))))
+    (when matching-indentation (indent-line-to matching-indentation) t)))
+
 (defun nix-mode-make-regexp (parts)
   "Combine the regexps into a single or-delimited regexp.
 PARTS a list of regexps"
@@ -513,6 +546,9 @@ PARTS a list of regexps"
                                             (looking-at "''")
                                             ) -1 0)
                                       )))))
+
+            ;; indent line after 'let', 'import', '[', '=', '(', '{'
+            ((nix-indent-first-line-in-block))
 
             ;; dedent '}', ']', ')' 'in'
             ((nix-indent-to-backward-match))


### PR DESCRIPTION
Add a function `nix-indent-first-line-in-block` that checks if the last word on the previous line is one of "let, import, [, =, (, {". Then it adds two spaces of indent to the one of the previous line.

This is a shot at improving based on the examples is #60.

It works with all examples in #60 and just by going through my configuration.nix it seems a lot better than before.

It's not perfect in all the cases like this:
```nix
let
  splitString = _sep: _s: builtins.filter
    (x: builtins.typeOf x == "string")
    (builtins.split _sep _s);
in # whatever
```

But it wasn't before either, in fact it behaves exactly the same as before in that case as far as I can see.