### PR TITLE
Remove line that caused tests to not indent at all in the tests and fix regression

### DIFF
--- a/nix-mode.el
+++ b/nix-mode.el
@@ -628,7 +628,6 @@ The hook `nix-mode-hook' is run when Nix mode is started.
 
   ;; Automatic indentation [C-j]
   (setq-local indent-line-function nix-indent-function)
-  (set (make-local-variable 'indent-region-function) 'nix-indent-region)
 
   ;; Indenting of comments
   (setq-local comment-start "# ")

--- a/nix-mode.el
+++ b/nix-mode.el
@@ -117,7 +117,7 @@ Valid functions for this are:
 
 (defconst nix-re-quotes "''\\|\"")
 
-(defconst nix-re-comments "#\\|/\\*\\|\\*/")
+(defconst nix-re-comments "#\\|/*\\|*/")
 
 (defconst nix-font-lock-keywords
   `((,(regexp-opt nix-keywords 'symbols) 0 'nix-keyword-face)

--- a/tests/nix-mode-tests.el
+++ b/tests/nix-mode-tests.el
@@ -70,7 +70,7 @@ function to do the indentation tests."
        ;; Run additional tests
        ,@body)))
 
-(ert-deftest nix-mode-indent-test-list-contents ()
+(ert-deftest nix-mode-test-indent-list-contents ()
   "Proper indentation for items inside of a list."
   (with-nix-mode-test ("list-contents.nix" :indent t)))
 

--- a/tests/nix-mode-tests.el
+++ b/tests/nix-mode-tests.el
@@ -70,6 +70,20 @@ function to do the indentation tests."
        ;; Run additional tests
        ,@body)))
 
+(ert-deftest nix-mode-test-indent-failed-ident ()
+  "Proper indentation for items inside of a list."
+  (with-nix-mode-test
+   ;; File to read
+   ("failed-ident-test.nix")
+
+   ;; Indent the buffer
+   (indent-region (point-min) (point-max))
+
+   ;; Compare buffer to the stored buffer contents
+   (should-not (equal
+                (buffer-substring-no-properties (point-min) (point-max))
+                raw-file))))
+
 (ert-deftest nix-mode-test-indent-list-contents ()
   "Proper indentation for items inside of a list."
   (with-nix-mode-test ("list-contents.nix" :indent t)))

--- a/tests/testcases/failed-ident-test.nix
+++ b/tests/testcases/failed-ident-test.nix
@@ -1,0 +1,7 @@
+# This file is wrongly idented on purpose to have a failing test if the indent
+# doesn't run at all.
+[
+47
+"string"
+true
+]


### PR DESCRIPTION
This fixes #64.

Still work in progress. Just wanted to see the test failure from travis.