### PR TITLE
fix-issue-72: Check the correct element from syntax-ppss

### DIFF
--- a/nix-mode.el
+++ b/nix-mode.el
@@ -519,7 +519,7 @@ STRING-TYPE type of string based off of Emacs syntax table types"
 
 (defun nix-is-comment-p ()
   "Whether we are in a comment."
-  (nth 3 (syntax-ppss)))
+  (nth 4 (syntax-ppss)))
 
 (defun nix-is-string-p ()
   "Whether we are in a string."

--- a/tests/nix-mode-tests.el
+++ b/tests/nix-mode-tests.el
@@ -118,5 +118,11 @@ Related issue: https://github.com/NixOS/nix-mode/issues/69"
 Related issue: https://github.com/NixOS/nix-mode/issues/69"
   (with-nix-mode-test ("issue-60.2.nix" :indent t)))
 
+(ert-deftest nix-mode-test-indent-issue-72 ()
+  "Proper indentation of strings in a multi-line string.
+
+Related issue: https://github.com/NixOS/nix-mode/issues/72"
+  (with-nix-mode-test ("issue-72.nix" :indent t)))
+
 (provide 'nix-mode-tests)
 ;;; nix-mode-tests.el ends here

--- a/tests/testcases/issue-72.nix
+++ b/tests/testcases/issue-72.nix
@@ -1,0 +1,6 @@
+# Test to make sure nix-mode indents the contents of the string two spaces.
+{
+  foo = ''
+    bar
+  '';
+}


### PR DESCRIPTION
This is kinda a semi-revert from a small change in
bb602e160fa5bb8ae15b113ebf308f0fb30b3aa9 where the code:

"(nth 4 (syntax-ppss))"

was replaced with a function that did:

"(nth 3 (syntax-ppss))"

cc @grahamc

I'm going to go ahead and merge this since it repairs more than it destroys (currently we don't indent our multi-line strings at all and the issues you raised in #73 existed before as well so I'm going to report that as a separate issue.)