### PR TITLE
Improve indentation of let expressions

### DIFF
--- a/tests/nix-mode-tests.el
+++ b/tests/nix-mode-tests.el
@@ -197,5 +197,9 @@ Related issue: https://github.com/NixOS/nix-mode/issues/72"
   "Proper indentation of closing parentheses."
   (with-nix-mode-test ("smie-close-parens.nix" :indent 'smie-indent-line)))
 
+(ert-deftest nix-mode-test-let-smie ()
+  "Proper indentation of let expressions."
+  (with-nix-mode-test ("smie-let.nix" :indent 'smie-indent-line)))
+
 (provide 'nix-mode-tests)
 ;;; nix-mode-tests.el ends here

--- a/tests/testcases/smie-let.nix
+++ b/tests/testcases/smie-let.nix
@@ -1,0 +1,45 @@
+let
+  foo = 42;
+  bar = let foo = 42; in
+        let bar = 42; in
+        42;
+  baz = 42;
+in
+let foo = 42; in
+let foo = 42;
+    bar = 42;
+in
+let foo = let
+      bar = 42;
+    in
+      42;
+    bar = 42;
+in
+let
+  foo = let
+    bar = 42;
+  in
+    42;
+  bar = 42;
+in
+let foo = 42;
+in
+{
+  foo = let
+    bar = 42;
+  in
+    42;
+
+  foo = let bar = 42;
+        in 42;
+
+  foo = let bar = 42; in
+        42;
+
+  foo =
+    let
+      foo = 42;
+      bar = 42;
+    in
+      42;
+}


### PR DESCRIPTION
Currently, the expression:
```nix
let foo = 42;
in foo
```
is indented as:
```nix
let foo = 42;
    in foo
```
I've added a test and fixed the issue.