### PR TITLE
Fix handling of keywords in identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ result
 *.tex
 *.pdf
 auto/
+
+AUTHORS.md

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,16 @@ ELS  =  nix.el nix-company.el nix-drv-mode.el nix-format.el \
 	nix-shell.el nix-store.el
 ELCS = $(ELS:.el=.elc)
 
+TESTS = tests/nix-mode-tests.el tests/nix-font-lock-tests.el
+
 DESTDIR =
 PREFIX  = /usr
 
 all: $(ELCS) nix-mode.info nix-mode.html AUTHORS.md
 
-check:
+check: $(TESTS) $(ELCS)
 	emacs   -batch -L . \
-		-l tests/nix-mode-tests.el \
-		-l tests/nix-font-lock-tests.el \
+		$(foreach test,$(TESTS),-l $(test)) \
 		-f ert-run-tests-batch-and-exit
 
 install: $(ELCS) nix-mode.info nix-mode.html AUTHORS.md

--- a/nix-mode.el
+++ b/nix-mode.el
@@ -132,9 +132,9 @@ very large Nix files (all-packages.nix)."
   "Produce a regexp matching some keywords of Nix.
 KEYWORDS a list of strings to match as Nix keywords."
   (concat
-   "\\(?:[[:space:]]\\|^\\)"
+   "\\(?:[[:space:];:{}()]\\|^\\)"
    (regexp-opt keywords t)
-   "\\(?:[[:space:]]\\|$\\)"
+   "\\(?:[[:space:];:{}()]\\|$\\)"
    ))
 
 (defconst nix-font-lock-keywords

--- a/nix-mode.el
+++ b/nix-mode.el
@@ -128,10 +128,19 @@ very large Nix files (all-packages.nix)."
 
 (defconst nix-re-comments "#\\|/*\\|*/")
 
+(defun nix-re-keywords (keywords)
+  "Produce a regexp matching some keywords of Nix.
+KEYWORDS a list of strings to match as Nix keywords."
+  (concat
+   "\\(?:[[:space:]]\\|^\\)"
+   (regexp-opt keywords t)
+   "\\(?:[[:space:]]\\|$\\)"
+   ))
+
 (defconst nix-font-lock-keywords
-  `((,(regexp-opt nix-keywords 'symbols) 0 'nix-keyword-face)
-    (,(regexp-opt nix-warning-keywords 'symbols) 0 'nix-keyword-warning-face)
-    (,(regexp-opt nix-builtins 'symbols) 0 'nix-builtin-face)
+  `((,(nix-re-keywords nix-keywords) 1 'nix-keyword-face)
+    (,(nix-re-keywords nix-warning-keywords) 1 'nix-keyword-warning-face)
+    (,(nix-re-keywords nix-builtins) 1 'nix-builtin-face)
     (,nix-re-url 0 'nix-constant-face)
     (,nix-re-file-path 0 'nix-constant-face)
     (,nix-re-variable-assign 1 'nix-attribute-face)

--- a/tests/nix-font-lock-tests.el
+++ b/tests/nix-font-lock-tests.el
@@ -76,7 +76,7 @@ if all of its characters have syntax and face. See
 
 (ert-deftest nix-issue-84 ()
   (check-properties
-   '("{ with-a ? { let-in = 1; } , ... }: with with-a; { foo = \"bar\"; }")
+   '("{ with-a ? {let-in=1; } , ... }:with with-a; { foo = \"bar\"; }")
    '(("let-in" t nix-attribute-face)
      ("with" t nix-keyword-face)
      ("foo" t nix-attribute-face))))

--- a/tests/nix-font-lock-tests.el
+++ b/tests/nix-font-lock-tests.el
@@ -40,7 +40,7 @@ after a test as this aids interactive debugging."
 (defun check-properties (lines-or-contents props &optional mode)
   "Check if syntax properties and font-lock properties as set properly.
 LINES is a list of strings that will be inserted to a new
-buffer. Then PROPS is a list of tripples of (string syntax
+buffer. Then PROPS is a list of triples of (string syntax
 face). String is searched for in the buffer and then is checked
 if all of its characters have syntax and face. See
 `check-syntax-and-face-match-range`."
@@ -64,7 +64,6 @@ if all of its characters have syntax and face. See
                               (search-forward string))
                             (check-syntax-and-face-match-range (match-beginning 0) (match-end 0) syntax face)))))
 
-
 (ert-deftest nix-equals-1 ()
   (check-properties
    '("pattern = 3")
@@ -74,6 +73,13 @@ if all of its characters have syntax and face. See
   (check-properties
    '("pattern == 3")
    '(("pattern" t nil))))
+
+(ert-deftest nix-issue-84 ()
+  (check-properties
+   '("{ with-a ? { let-in = 1; } , ... }: with with-a; { foo = \"bar\"; }")
+   '(("let-in" t nix-attribute-face)
+     ("with" t nix-keyword-face)
+     ("foo" t nix-attribute-face))))
 
 ;; Local Variables:
 ;; flycheck-disabled-checkers: (emacs-lisp-checkdoc)


### PR DESCRIPTION
This case shouldn’t be highlighted. For instance:

  python-with-my-packages

Need to look ahead and behind keywords to make sure they are not used
in attribute names.