### PR TITLE
SMIE: parse paths enclosed in angle brackets (e.g. <nixpkgs>) correctly

### DIFF
--- a/nix-mode.el
+++ b/nix-mode.el
@@ -530,10 +530,9 @@ STRING-TYPE type of string based off of Emacs syntax table types"
 (defun nix-smie--skip-path (how)
   "Skip path related characters."
   (let ((start (point)))
-    (pcase how
+    (pcase-exhaustive how
       ('forward (skip-chars-forward nix-smie--path-chars))
-      ('backward (skip-chars-backward nix-smie--path-chars))
-      (_ (error "expected 'forward or 'backward")))
+      ('backward (skip-chars-backward nix-smie--path-chars)))
     (let ((sub (buffer-substring-no-properties start (point))))
       (if (string-match-p "/" sub)
           sub

--- a/tests/nix-mode-tests.el
+++ b/tests/nix-mode-tests.el
@@ -27,6 +27,44 @@
             (nix-mode)
             (eq (nix--get-string-type (nix--get-parse-state (point))) nil))))
 
+(ert-deftest nix-smie-angle-path-backward-detection ()
+  (should (with-temp-buffer
+            (nix-mode)
+            (insert "<nixpkgs/nixos>")
+            (nix-smie--skip-angle-path-backward)
+            (bobp))))
+
+(ert-deftest nix-smie-angle-path-backward-invalid ()
+  (should (with-temp-buffer
+            (nix-mode)
+            (insert "<nixpkgs/nixos>foo/bar>")
+            (null (nix-smie--skip-angle-path-backward)))))
+
+(ert-deftest nix-smie-angle-path-backward-early ()
+  (should (with-temp-buffer
+            (nix-mode)
+            (insert "<nixpkgs/nixos<foo/bar>")
+            (equal "<foo/bar>" (nix-smie--skip-angle-path-backward)))))
+
+(ert-deftest nix-smie-angle-path-forward-detection ()
+  (should (with-temp-buffer
+            (nix-mode)
+            (save-excursion (insert "<nixpkgs/nixos>"))
+            (nix-smie--forward-token)
+            (eobp))))
+
+(ert-deftest nix-smie-angle-path-forward-invalid ()
+  (should (with-temp-buffer
+            (nix-mode)
+            (save-excursion (insert "<nixpkgs/nixos<foo/bar>"))
+            (null (nix-smie--skip-angle-path-forward)))))
+
+(ert-deftest nix-smie-angle-path-forward-early ()
+  (should (with-temp-buffer
+            (nix-mode)
+            (save-excursion (insert "<foo/bar>nixpkgs/nixos>"))
+            (equal "<foo/bar>" (nix-smie--skip-angle-path-forward)))))
+
 ;;; Indentation tests
 
 (defvar nix-mode-test-dir (expand-file-name "testcases"


### PR DESCRIPTION
Currently, the code parses the string `<nixpkgs>` as `<` `nixpkgs` `>`, while it should be parsed as a single token. This PR fixes that.