### PR TITLE
Dash syntax

### DIFF
--- a/nix-mode.el
+++ b/nix-mode.el
@@ -4,7 +4,7 @@
 ;; Homepage: https://github.com/NixOS/nix-mode
 ;; Version: 1.4.1
 ;; Keywords: nix, languages, tools, unix
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "25"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/nix-mode.el
+++ b/nix-mode.el
@@ -162,7 +162,7 @@ KEYWORDS a list of strings to match as Nix keywords."
     (modify-syntax-entry ?\n "> b" table)
     (modify-syntax-entry ?_ "_" table)
     (modify-syntax-entry ?. "'" table)
-    (modify-syntax-entry ?- "'" table)
+    (modify-syntax-entry ?- "_" table)
     (modify-syntax-entry ?' "'" table)
     (modify-syntax-entry ?= "." table)
     (modify-syntax-entry ?< "." table)


### PR DESCRIPTION
This gives "-" the "symbol" character class, since it is a legal symbol constituent

This still allows "-" to be highlighted correctly when used as a binary
or unary operator.

The PR also contains a fix for the currently incorrect Emacs version dependency clause.

Cheers!