### PR TITLE
Don't freeze full executable paths at load time

### DIFF
--- a/nix.el
+++ b/nix.el
@@ -22,27 +22,27 @@
   "Nix-related customizations"
   :group 'languages)
 
-(defcustom nix-executable (executable-find "nix")
+(defcustom nix-executable "nix"
   "Nix executable location."
   :group 'nix
   :type 'string)
 
-(defcustom nix-build-executable (executable-find "nix-build")
+(defcustom nix-build-executable "nix-build"
   "Nix-build executable location."
   :group 'nix
   :type 'string)
 
-(defcustom nix-instantiate-executable (executable-find "nix-instantiate")
+(defcustom nix-instantiate-executable "nix-instantiate"
   "Nix executable location."
   :group 'nix
   :type 'string)
 
-(defcustom nix-store-executable (executable-find "nix-store")
+(defcustom nix-store-executable "nix-store"
   "Nix executable location."
   :group 'nix
   :type 'string)
 
-(defcustom nix-shell-executable (executable-find "nix-shell")
+(defcustom nix-shell-executable "nix-shell"
   "Location of ‘nix-shell’ executable."
   :group 'nix
   :type 'string)


### PR DESCRIPTION
It's bad practice to use `executable-find` in defcustoms, because the value will be expanded into a fully-qualified path at the time the file is loaded, using whatever is the effective `exec-path` at the time. This can lead to confusion if the file is somehow loaded before a user deliberately sets up his path.

When only an executable name is used, as is the case with this change, it is looked up in the $PATH at the time it is used, which reliably leads to expected behaviour. And the user can of course still customise any `nix-*-executable` variable to a full path if they wish.