### PR TITLE
Improve symbol tokenization.

### DIFF
--- a/nix-mode.el
+++ b/nix-mode.el
@@ -590,8 +590,7 @@ STRING-TYPE type of string based off of Emacs syntax table types"
        (point)
        (progn
          (or (/= 0 (skip-syntax-forward "'w_"))
-             (nix-smie--skip-symbol 'forward)
-             (skip-syntax-forward ".'"))
+             (nix-smie--skip-symbol 'forward))
          (point)))))
 
 (defun nix-smie--forward-token ()
@@ -612,8 +611,7 @@ STRING-TYPE type of string based off of Emacs syntax table types"
        (point)
        (progn
          (or (/= 0 (skip-syntax-backward "'w_"))
-             (nix-smie--skip-symbol 'backward)
-             (skip-syntax-backward ".'"))
+             (nix-smie--skip-symbol 'backward))
          (point)))))
 
 (defun nix-smie--backward-token ()

--- a/nix-mode.el
+++ b/nix-mode.el
@@ -418,7 +418,7 @@ STRING-TYPE type of string based off of Emacs syntax table types"
        (right " -bseqskip- ")
        (left " -fseqskip- "))))))
 
-(defconst nix-smie--symbol-chars "[:->|&=!</-+*?,;!]")
+(defconst nix-smie--symbol-chars ":->|&=!</-+*?,;!")
 
 (defconst nix-smie--infix-symbols-re
   (regexp-opt '(":" "->" "||" "&&" "==" "!=" "<" "<=" ">" ">="
@@ -573,8 +573,8 @@ STRING-TYPE type of string based off of Emacs syntax table types"
        (point)
        (progn
          (or (/= 0 (skip-syntax-forward "'w_"))
-             (when (looking-at nix-smie--symbol-chars) (forward-char) t)
-             (skip-syntax-forward "'"))
+             (/= 0 (skip-chars-forward nix-smie--symbol-chars))
+             (skip-syntax-forward ".'"))
          (point)))))
 
 (defun nix-smie--forward-token ()
@@ -595,8 +595,8 @@ STRING-TYPE type of string based off of Emacs syntax table types"
        (point)
        (progn
          (or (/= 0 (skip-syntax-backward "'w_"))
-             (when (looking-back nix-smie--symbol-chars) (backward-char) t)
-             (skip-syntax-backward "'"))
+             (/= 0 (skip-chars-backward nix-smie--symbol-chars))
+             (skip-syntax-backward ".'"))
          (point)))))
 
 (defun nix-smie--backward-token ()

--- a/nix-mode.el
+++ b/nix-mode.el
@@ -577,7 +577,7 @@ STRING-TYPE type of string based off of Emacs syntax table types"
              (member (buffer-substring-no-properties (point) start)
                      nix-smie--2char-symbols))
         (if (< 0 abs-skip)
-            (goto-char (+ start (signum nskip)))
+            (goto-char (+ start (if (< 0 nskip) 1 -1)))
           (goto-char start)
           nil))))
 

--- a/tests/nix-mode-tests.el
+++ b/tests/nix-mode-tests.el
@@ -231,7 +231,7 @@ Related issue: https://github.com/NixOS/nix-mode/issues/72"
   "Proper indentation of attrsets inside of lists inside of attrsets.
 
 Related issue: https://github.com/NixOS/nix-mode/issues/94"
-  (with-nix-mode-test ("issue-60.1.nix" :indent 'smie-indent-line)))
+  (with-nix-mode-test ("issue-94.nix" :indent 'smie-indent-line)))
 
 (ert-deftest nix-mode-test-indent-lambdas-smie ()
   "Proper indentation of function bodies."


### PR DESCRIPTION
#97 incorrectly handles multi-character symbols such as `==`.
This PR fixes #94 while correctly tokenizing multi-character symbols.