### PR TITLE
Fix nix-get-completions, add to nix-repl-mode

### DIFF
--- a/nix-repl.el
+++ b/nix-repl.el
@@ -29,6 +29,11 @@
   "Time in seconds to wait for completion output before giving up."
   :type 'float)
 
+(defvar nix-repl-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "\t" 'completion-at-point)
+    map))
+
 (define-derived-mode nix-repl-mode comint-mode "Nix-REPL"
   "Interactive prompt for Nix."
   (setq-local comint-prompt-regexp nix-prompt-regexp)


### PR DESCRIPTION
A mashup of python's completion-at-point function and @purcell's [sketch](https://github.com/NixOS/nix-mode/pull/39#issuecomment-360968725).  

This is working for me via `company-capf` on nix-2.3.7.