### PR TITLE
Set the 'LD_LIBRARY_PATH' environment variable for mkShell

### DIFF
--- a/nix-shell.el
+++ b/nix-shell.el
@@ -158,7 +158,14 @@ The DRV file to use."
       (when ld-library-path
 	(make-local-variable 'process-environment)
 	(setq process-environment
-	      (cons (format "LD_LIBRARY_PATH=%s" ld-library-path)
+	      (cons
+	       (let*
+		   ((var "LD_LIBRARY_PATH")
+		    (current-path (getenv var)))
+		 (if current-path
+		     ;; LD_LIBRARY_PATH defined in derivation takes precedence
+		     (format "%s=%s:%s" var ld-library-path current-path)
+		   (format "%s=%s" var ld-library-path)))
 		    process-environment)))
 
       (dolist (input inputs)

--- a/nix-shell.el
+++ b/nix-shell.el
@@ -131,7 +131,9 @@ The DRV file to use."
 			 (apply 'append
 				(mapcar (lambda (prop)
 					  (split-string (alist-get prop env)))
-					nix-shell-inputs)))))
+					nix-shell-inputs))))
+	 ;; This attribute is in `mkShell' — ideally, we'd only check this variable in those cases.
+	 (ld-library-path (alist-get 'LD_LIBRARY_PATH env)))
 
     ;; Prevent accidentally rebuilding the world.
     (unless (file-directory-p stdenv)
@@ -151,6 +153,13 @@ The DRV file to use."
 	(setq-local eshell-path-env "")
 	;; (setq-local process-environment nil)
 	)
+
+      ;; Set the LD_LIBRARY_PATH where applicable
+      (when ld-library-path
+	(make-local-variable 'process-environment)
+	(setq process-environment
+	      (cons (format "LD_LIBRARY_PATH=%s" ld-library-path)
+		    process-environment)))
 
       (dolist (input inputs)
 	(when (and (not (file-directory-p input))


### PR DESCRIPTION
This relies on the `LD_LIBRARY_PATH` attribute in the `mkShell` derivation and won't work for other commonly used methods such as setting the `shellHook` attribute.

I believe this is a common enough use-case to warrant adding into the code-base.