### PR TITLE
Makefile: add nix-mode project directory to 'load-path' in 'run' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clean:
 	rm -f $(ELCS) $(DOCS)
 
 run:
-	emacs -Q -l nix-mode.el
+	emacs -Q -L . -l nix-mode.el
 
 %.elc: %.el
 	emacs -batch -L . --eval "(progn\


### PR DESCRIPTION
Emacs will fail to load our local nix-foo.el unless we append the
project directory to 'load-path'.


----

#