### PR TITLE
Update install-nix-action in GitHub Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: cachix/install-nix-action@v10
+    - uses: cachix/install-nix-action@v12
     #- run: nix build
     - run: nix-build -E '(import ./.).defaultPackage.${builtins.currentSystem}'
     #- run: nix flake check


### PR DESCRIPTION
This should fix the following error:

```
Error: Unable to process command '::add-path::/nix/var/nix/profiles/per-user/runner/profile/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

See also: https://github.com/cachix/install-nix-action/issues/50