### PR TITLE
Make nix-drv-mode a derived-mode of javascript-mode

### DIFF
--- a/nix-drv-mode.el
+++ b/nix-drv-mode.el
@@ -19,30 +19,33 @@
 (require 'javascript-mode)
 (require 'nix)
 
-(defvar-local nix-drv-mode nil)
+;;;###autoload
+(define-derived-mode nix-drv-mode javascript-mode "Nix-Derivation"
+  "Pretty print Nix’s .drv files."
+  (let ((inhibit-read-only t))
+    (erase-buffer)
+    (insert (shell-command-to-string
+             (format "%s show-derivation \"%s\""
+		     nix-executable
+		     (buffer-file-name))))
+    (set-buffer-modified-p nil)
+    (read-only-mode 1))
+
+  (add-hook 'change-major-mode-hook #'nix-drv-mode-dejsonify-buffer nil t))
+
+(defun nix-drv-mode-dejsonify-buffer ()
+  "Restore nix-drv-mode when switching to another mode."
+
+  (remove-hook 'change-major-mode-hook #'nix-drv-mode-dejsonify-buffer t)
+
+  (let ((inhibit-read-only t))
+    (erase-buffer)
+    (insert-file-contents (buffer-file-name))
+    (set-buffer-modified-p nil)
+    (read-only-mode nil)))
 
 ;;;###autoload
-(defun nix-drv-mode ()
-  "Pretty print Nix’s .drv files."
-  (interactive)
-  (when (string-match (format "^%s/" nix-store-dir) (buffer-file-name))
-    (if nix-drv-mode
-        (progn
-          (erase-buffer)
-          (insert-file-contents (buffer-file-name))
-          (setq nix-drv-mode nil)
-          (set-buffer-modified-p nil)
-          (read-only-mode nil))
-      (let ((inhibit-read-only t))
-        (setq nix-drv-mode t)
-        (erase-buffer)
-        (insert (shell-command-to-string
-                 (format "%s show-derivation \"%s\""
-		         nix-executable
-		         (buffer-file-name))))
-        (javascript-mode)
-        (set-buffer-modified-p nil)
-        (read-only-mode 1)))))
+(add-to-list 'auto-mode-alist '("\\.drv\\'" . nix-drv-mode))
 
 (provide 'nix-drv-mode)
 ;;; nix-drv-mode.el ends here


### PR DESCRIPTION
This makes nix-drv-mode derived from javascript-mode. Cleanup is done
on change major mode. Cleanup can also be done manually via
nix-drv-mode-dejsonify-buffer.