### PR TITLE
Use the located nixfmt binary for formatting.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1595687772,
-        "narHash": "sha256-8HukW/hw+g20I1WrL8QyVftG7WWrSqIDL/z6HFQZyy4=",
+        "lastModified": 1609725427,
+        "narHash": "sha256-Yn97AVjFvQunGmwK3nnr7LihzMnp72jyaYNRRaJvAZ4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "076c67fdea6d0529a568c7d0e0a72e6bc161ecf5",
+        "rev": "c5c6009fb436efe5732e07cd0e5692f495321752",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-20.03-small",
+        "ref": "nixos-20.09-small",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "An emacs major mode for editing Nix expressions";
 
-  inputs.nixpkgs.url = "nixpkgs/nixos-20.03-small";
+  inputs.nixpkgs.url = "nixpkgs/nixos-20.09-small";
 
   outputs = { self, nixpkgs }: let
     systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" ];

--- a/nix-format.el
+++ b/nix-format.el
@@ -13,24 +13,29 @@
   :group 'nix
   :type 'string)
 
-(defun nix--format-call (buf)
+(defun nix--format-call (buf nixfmt-bin)
   "Format BUF using nixfmt."
   (with-current-buffer (get-buffer-create "*nixfmt*")
     (erase-buffer)
     (insert-buffer-substring buf)
-    (if (zerop (call-process-region (point-min) (point-max) nix-nixfmt-bin t t nil))
+    (if (zerop (call-process-region (point-min) (point-max) nixfmt-bin t t nil))
         (progn
           (if (not (string= (buffer-string) (with-current-buffer buf (buffer-string))))
               (copy-to-buffer buf (point-min) (point-max)))
           (kill-buffer))
       (error "Nixfmt failed, see *nixfmt* buffer for details"))))
 
+(defun nix--find-nixfmt ()
+  "Find the nixfmt binary, or error if it's missing."
+  (let ((nixfmt-bin (executable-find nix-nixfmt-bin)))
+    (unless nixfmt-bin
+      (error "Could not locate executable \"%s\"" nix-nixfmt-bin))
+    nixfmt-bin))
+
 (defun nix-format-buffer ()
   "Format the current buffer using nixfmt."
   (interactive)
-  (unless (executable-find nix-nixfmt-bin)
-    (error "Could not locate executable \"%s\"" nix-nixfmt-bin))
-  (nix--format-call (current-buffer))
+  (nix--format-call (current-buffer) (nix--find-nixfmt))
   (message "Formatted buffer with nixfmt."))
 
 (provide 'nix-format)


### PR DESCRIPTION
Allows use with `nixfmt` installed using direnv ([envrc-mode]).

Before:

1. `nix-format-buffer` checks for `nixfmt`: `(executable-find nix-nixfmt-bin)`
2. If it's missing, error. Otherwise, disregard the path to `nixfmt`
   that we just found.
3. Open a new buffer (if using `envrc-mode`, with a totally different
   `$PATH`) and try to run `nix-nixfmt-bin`.

If you had `nixfmt` installed in your direnv but not globally, this
gives an error: "Searching for program: No such file or directory, nixfmt".

Now, we use the path that we just found and `call-process-region` on that.

[envrc-mode]: https://github.com/purcell/envrc