### PR TITLE
Add version to define-obsolete-function-alias for nix-prettify-mode

### DIFF
--- a/nix-prettify-mode.el
+++ b/nix-prettify-mode.el
@@ -173,7 +173,7 @@ See `nix-prettify-special-modes' for details."
   nix-prettify-mode nix-prettify-turn-on)
 
 ;;;###autoload
-(define-obsolete-function-alias 'global-nix-prettify-mode 'nix-prettify-global-mode)
+(define-obsolete-function-alias 'global-nix-prettify-mode 'nix-prettify-global-mode "1.2.2")
 
 (provide 'nix-prettify-mode)
 


### PR DESCRIPTION
This argument has become required in later versions of GNU Emacs. I backtracked where the function was marked obsolete and added that version. I see that the version is not updated in this specific file, but I guess the important part is to match the package version.