### PR TITLE
Fix for Emacs 28.0.50

### DIFF
--- a/nix-prettify-mode.el
+++ b/nix-prettify-mode.el
@@ -173,7 +173,7 @@ See `nix-prettify-special-modes' for details."
   nix-prettify-mode nix-prettify-turn-on)
 
 ;;;###autoload
-(define-obsolete-function-alias 'global-nix-prettify-mode 'nix-prettify-global-mode)
+(define-obsolete-function-alias 'global-nix-prettify-mode 'nix-prettify-global-mode "28.0.50")
 
 (provide 'nix-prettify-mode)
 


### PR DESCRIPTION
This is a small change needed to support emacs master 28.  Apparently, the "when" argument is now required for `define-obsolete-function-alias`.  The thing is I don't know precisely what value to put in here since I don't know what the version number was when the function `global-nix-prettify-mode` became obsolete.