### PR TITLE
Add version number for obsolete function.

### DIFF
--- a/nix-prettify-mode.el
+++ b/nix-prettify-mode.el
@@ -173,7 +173,7 @@ See `nix-prettify-special-modes' for details."
   nix-prettify-mode nix-prettify-turn-on)
 
 ;;;###autoload
-(define-obsolete-function-alias 'global-nix-prettify-mode 'nix-prettify-global-mode)
+(define-obsolete-function-alias 'global-nix-prettify-mode 'nix-prettify-global-mode "v1.4.5")
 
 (provide 'nix-prettify-mode)
 


### PR DESCRIPTION
As of https://github.com/emacs-mirror/emacs/commit/32c6732d16385f242b1109517f25e9aefd6caa5c the when argument is required. Resolves https://github.com/NixOS/nix-mode/issues/125.