### PR TITLE
nix-drv-mode.el: make regexp more selective

### DIFF
--- a/nix-drv-mode.el
+++ b/nix-drv-mode.el
@@ -45,7 +45,7 @@
     (read-only-mode nil)))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.drv\\'" . nix-drv-mode))
+(add-to-list 'auto-mode-alist '("\\`/nix/store/.+\\.drv\\'". nix-drv-mode))
 
 (provide 'nix-drv-mode)
 ;;; nix-drv-mode.el ends here


### PR DESCRIPTION
In the Auctex package, latex.el adds '("\\.drv\\'" . latex-mode) to auto-mode-alist, so we
prefer to use some other regexp to avoid opening Nix derivations in the wrong mode.

I made the following patch to Auctex upstream just now:

``` elisp
(add-to-list 'auto-mode-alist '("\\.drv\\'" . latex-mode) t) ;; append to the end of `auto-mode-alist' to give higher priority to Guix/Nix's derivation modes
```

This way, the Nix-derivation regexp always gets checked first. I'm not aware of a quick way of mimicking a lookahead assertion in the Auctex regexp, but that would probably be preferable to what I did.