### PR TITLE
Refactor process calling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
           org-plus-contrib
           company
           mmm-mode
+          f
         ]);
       in stdenvNoCC.mkDerivation {
         name = "nix-mode-1.4.5";

--- a/nix-instantiate.el
+++ b/nix-instantiate.el
@@ -17,19 +17,8 @@
 (defun nix-instantiate--parsed (drv)
   "Get the parsed version of the .drv file.
 DRV file to load from."
-  (let ((stdout (generate-new-buffer "nix show-derivation"))
-	result)
-    (call-process nix-executable nil (list stdout nil) nil
-		  "show-derivation" drv)
-    (setq result
-	  (cdar (with-current-buffer stdout
-		  (when (eq (buffer-size) 0)
-		    (error "Nix’s show-derivation %s failed to produce any output"
-			   drv))
-		  (goto-char (point-min))
-		  (json-read))))
-    (kill-buffer stdout)
-    result))
+  (cdar
+    (nix--process-json "show-derivation" drv)))
 
 (defun nix-instantiate (nix-file &optional attribute parse)
   "Run nix-instantiate on a Nix expression.

--- a/nix-mode.el
+++ b/nix-mode.el
@@ -913,11 +913,9 @@ location of STR. If `nix-instantiate' has a nonzero exit code,
 don’t do anything"
   (when (and (string-match nix-re-bracket-path str)
              (executable-find nix-instantiate-executable))
-    (with-temp-buffer
-      (when (eq (call-process nix-instantiate-executable nil (current-buffer)
-                              nil "--eval" "-E" str) 0)
-        ;; Remove trailing newline
-        (substring (buffer-string) 0 (- (buffer-size) 1))))))
+    (let ((nix-executable nix-instantiate-executable))
+      (ignore-errors
+	(nix--process-string "--eval" "-E" str)))))
 
 ;; Key maps
 

--- a/nix-search.el
+++ b/nix-search.el
@@ -18,14 +18,10 @@
 
 ;;;###autoload
 (defun nix-search--search (search file &optional no-cache use-flakes)
-  (with-temp-buffer
-    (if use-flakes
-	(call-process nix-executable nil (list t nil) nil
-		      "search" "--json" file (if (string= search "") "." search))
-      (call-process nix-executable nil (list t nil) nil
-		    "search" "--json" (if no-cache "--no-cache" "") "--file" file search))
-    (goto-char (point-min))
-    (json-read)))
+  (nix--process-json-nocheck "search" "--json"
+    (if use-flakes "" "--file") file
+    (if no-cache  "--no-cache" "")
+    search))
 
 (defface nix-search-pname
   '((t :height 1.5


### PR DESCRIPTION
This commit reworks the usage of calling a nix process. With this you
can now get more meaningful error messages:

``` emacs-lisp
ELISP> (nix-instantiate--parsed "xxx")
*** Eval error ***  error: attribute ’xxx’ in selection path ’xxx’ not found
```

Before this commit, a call such as this would result in:
``` emacs-lisp
ELISP> (nix-instantiate--parsed "xxx")
*** Eval error ***  Nix’s show-derivation xxx failed to produce any output
```