### PR TITLE
Add Package-Requires for dependency on "f"

### DIFF
--- a/nix-mode.el
+++ b/nix-mode.el
@@ -4,7 +4,7 @@
 ;; Homepage: https://github.com/NixOS/nix-mode
 ;; Version: 1.4.4
 ;; Keywords: nix, languages, tools, unix
-;; Package-Requires: ((emacs "25.1"))
+;; Package-Requires: ((emacs "25.1") (f "0.20.0"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
I'm managing emacs packages with straight instead of nix, but loading nix-mode failed because there's now a dependency on the library `f`. The `nix-mode.el` says `(require 'nix)` which in turn has `(require 'f)`.

Straight derives its dependency graph from the `Package-Requires` header, so this PR updates that it to work correctly with straight. Hope it helps someone else!