### PR TITLE
Use replace-buffer-contents for better formatting experience

### DIFF
--- a/nix-format.el
+++ b/nix-format.el
@@ -35,7 +35,7 @@
   "Find the nixfmt binary, or error if it's missing."
   (let ((nixfmt-bin (executable-find nix-nixfmt-bin)))
     (unless nixfmt-bin
-      (error "Could not locate executable \"%s\"" nix-nixfmt-bin))
+      (error "Could not locate executable %S" nix-nixfmt-bin))
     nixfmt-bin))
 
 (defun nix-format-buffer ()


### PR DESCRIPTION
In nix-format.el, use `replace-buffer-contents`, if it is available, to rewrite the buffer with the formatted output.  This is somewhat more efficient for large buffers, but mainly it avoids resetting the point to the beginning of the buffer and thus also the scroll position, which is annoying to recover from.