### PR TITLE
nix-format.el: Add nix-format-before-save

### DIFF
--- a/nix-format.el
+++ b/nix-format.el
@@ -38,5 +38,11 @@
   (nix--format-call (current-buffer) (nix--find-nixfmt))
   (message "Formatted buffer with nixfmt."))
 
+;;;###autoload
+(defun nix-format-before-save ()
+  "Add this to `before-save-hook' to run nixfmt when saving."
+  (when (derived-mode-p 'nix-mode)
+    (nix-format-buffer)))
+
 (provide 'nix-format)
 ;;; nix-format.el ends here


### PR DESCRIPTION
This is an autoloaded function suitable for adding to
the global `before-save-hook`.