### PR TITLE
Remove f dependency

### DIFF
--- a/nix-mode.el
+++ b/nix-mode.el
@@ -4,7 +4,7 @@
 ;; Homepage: https://github.com/NixOS/nix-mode
 ;; Version: 1.4.4
 ;; Keywords: nix, languages, tools, unix
-;; Package-Requires: ((emacs "25.1") (f "0.20.0"))
+;; Package-Requires: ((emacs "25.1"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/nix.el
+++ b/nix.el
@@ -18,7 +18,6 @@
 
 (require 'pcomplete)
 (require 'json)
-(require 'f)
 
 (defgroup nix nil
   "Nix-related customizations"
@@ -331,7 +330,9 @@ OPTIONS a list of options to accept."
     (let* ((tmpfile  (make-temp-file "nix--process-stderr"))
 	 (cleaned-args (seq-filter #'stringp args))
 	 (exitcode (apply #'call-process `(,nix-executable nil (t ,tmpfile) nil ,@cleaned-args )))
-	 (stderr (f-read-text tmpfile)))
+	 (stderr (with-temp-buffer
+		   (insert-file-contents tmpfile)
+		   (buffer-string))))
       (delete-file tmpfile)
       (list (buffer-string) stderr exitcode))))
 


### PR DESCRIPTION
A while back f was added as a dependency, despite only being used once. I am trying to package nix-mode as part of [NonGNU ELPA](https://elpa.nongnu.org/), and would like to avoid adding f if possible. This patch removes the unnecessary dependency.