### PR TITLE
nix.el: Fix for Nix 2.5

### DIFF
--- a/nix.el
+++ b/nix.el
@@ -186,10 +186,11 @@ OPTIONS a list of options to accept."
 
 (defun nix-is-24 ()
   "Whether Nix is a version with Flakes support."
-  ;; earlier versions reported as 3, now it’s just nix-2.4
   (let ((version (nix-version)))
-    (or (string-prefix-p "nix (Nix) 3" version)
-        (string-prefix-p "nix (Nix) 2.4" version))))
+    (save-match-data
+      (when (string-match (rx bol "nix (Nix) " (group (+ digit) (?  "." (+ digit))))
+                          version)
+        (version<= "2.4" (match-string 1 version))))))
 
 (defun nix-has-flakes ()
   "Whether Nix is a version with Flakes support."


### PR DESCRIPTION
Hello, the current implementation of `nix-is-24` supports 3.x and 2.4 of the Nix package manager, but my installation is now 2.5:

> nix (Nix) 2.5pre20211007_844dd90

Of course, the function should return non-nil in this case as well, which is why I am writing this PR.

It would be possible to add another `string-prefix-p` case for 2.5, but there may be 2.6 in the future, so I think it is better to properly compare the versions, which has led to my implementation.

I would like to hear your opinion. If you like it, please feel free to merge the PR.