### PR TITLE
Add dependabot.yml for updating GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5
+  commit-message:
+    prefix: "chore"
+    include: "scope"


### PR DESCRIPTION
This will notify new releases of actions (currently install-nix-action) used in the workflow.