### PR TITLE
nix-mode: Add missing transient dependency for nix-flake

### DIFF
--- a/nix-mode.el
+++ b/nix-mode.el
@@ -4,7 +4,7 @@
 ;; Homepage: https://github.com/NixOS/nix-mode
 ;; Version: 1.4.4
 ;; Keywords: nix, languages, tools, unix
-;; Package-Requires: ((emacs "25.1") magit-section)
+;; Package-Requires: ((emacs "25.1") magit-section (transient "0.3"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
Hello, this is a fix related to #140. This is necessary unless we distribute `nix-flake.el` as a separate package (see #148).