### PR TITLE
Recent `show-config --json` format adaptation

### DIFF
--- a/nix-mode.org
+++ b/nix-mode.org
@@ -103,7 +103,7 @@ to set up just nix-mode without use-package:
 
 *** nix-mode
 
-This is a major mode for editing Nix expressons. It provides syntax
+This is a major mode for editing Nix expressions. It provides syntax
 highlighting, sane defaults, and experimental indentation support.
 
 You can set it up to handle .nix files with,
@@ -183,8 +183,8 @@ First, there are 3 commands that run Nix phases for you.
 - nix-shell-configure
 - nix-shell-build
 
-You can run any one of these to invode the correspond Nix phase. For
-instance to unpack the source for Emacs, let’s start from a dired
+You can run any one of these to invoke the corresponding Nix phase. For
+instance, to unpack the source for Emacs, let’s start from a dired
 buffer,
 
 #+BEGIN_SRC text
@@ -195,7 +195,7 @@ C-x C-f ~ RET
 M-x nix-shell-unpack RET emacs RET
 #+END_SRC
 
-This will unpack the Emacs soure code. It may take a minute or two to
+This will unpack the Emacs source code. It may take a minute or two to
 unpack. After that, we can enter the Emacs directory with find-file,
 
 #+BEGIN_SRC text

--- a/nix-search.el
+++ b/nix-search.el
@@ -75,6 +75,7 @@
   "Major mode for showing Nix search results.
 
 \\{nix-search-mode-map}"
+  :interactive nil
   :group 'nix-mode
 
   (easy-menu-add nix-search-mode-menu)

--- a/nix-search.el
+++ b/nix-search.el
@@ -19,8 +19,8 @@
 ;;;###autoload
 (defun nix-search--search (search file &optional no-cache use-flakes)
   (nix--process-json-nocheck "search" "--json"
-    (if use-flakes "" "--file") file
-    (if no-cache  "--no-cache" "")
+    (unless use-flakes "--file") file
+    (when no-cache "--no-cache")
     search))
 
 (defface nix-search-pname

--- a/nix.el
+++ b/nix.el
@@ -18,6 +18,8 @@
 
 (require 'pcomplete)
 (require 'json)
+(eval-when-compile
+  (require 'let-alist))
 
 (defgroup nix nil
   "Nix-related customizations"
@@ -196,7 +198,8 @@ OPTIONS a list of options to accept."
   "Whether Nix is a version with Flakes support."
   ;; earlier versions reported as 3, now it’s just nix-2.4
   (and (nix-is-24)
-       (seq-contains-p (alist-get 'value (alist-get 'experimental-features (nix-show-config))) "flakes")))
+    (let-alist (nix-show-config)
+      (seq-contains-p .experimental-features.value "flakes"))))
 
 ;;;###autoload
 (defun pcomplete/nix ()


### PR DESCRIPTION
For me currently, the function `(nix-has-flakes)` is broken, meaning it returns nil, when I actually have flakes active. This is because, on my system at least, the `nix show-config --json` returns integers in the `experimental-features` key. Therefore this command does not recognise it.

This PR adapts to this observed change. For for information, please see the commit messages.

Do you also have the same problem and does this fix it for you? Should we still check for the string version of the value?