### PR TITLE
Add `nix-store-show-log` to open a log file from nix-store-path mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,11 @@ overview of a store path. The information it shows is the realisation status,
 the hash and the size of the store path. Also it shows lists of derivers,
 references, referrers and requisites of the respective path.
 
-You can change the order in which that information is show. See the
+You can change the order in which that information is shown. See the
 documentation of the function `nix-store-show-path` for more information.
+
+When viewing a store buffer, the command `M-x nix-store-show-log`
+opens a local log file associated with a derivation.
 
 ### nix-prettify-mode.el
 

--- a/nix-log.el
+++ b/nix-log.el
@@ -16,6 +16,16 @@
 (require 'nix)
 (require 'nix-search)
 (require 'nix-instantiate)
+(require 'files)
+
+(defun nix-log-path (drv-file)
+  "Get the nix log of path a derivation"
+  (let* ((drv-name (file-relative-name drv-file nix-store-dir))
+	 (log-file (format "%s/log/nix/drvs/%s/%s.bz2"
+                           nix-state-dir
+                           (substring drv-name 0 2) (substring drv-name 2))))
+    (if (file-exists-p log-file) log-file
+      (error "No log is available for derivation"))))
 
 ;;;###autoload
 (defun nix-log (file attr)
@@ -26,15 +36,8 @@ ATTR attribute to load the log of."
   (unless attr (setq attr (nix-read-attr file)))
 
   (let* ((drv-file (nix-instantiate file attr))
-         (drv-name (progn
-                     (string-match (format "^%s/\\(.*\\)$" nix-store-dir) drv-file)
-                     (match-string 1 drv-file)))
-         (log-file (format "%s/log/nix/drvs/%s/%s.bz2"
-                           nix-state-dir
-                           (substring drv-name 0 2) drv-name)))
-    (if (file-exists-p log-file)
-        (find-file log-file)
-      (error "No log is available for derivation"))))
+         (log-file (nix-log-path drv-file)))
+    (find-file log-file)))
 
 (provide 'nix-log)
 ;;; nix-log.el ends here

--- a/nix-store.el
+++ b/nix-store.el
@@ -14,6 +14,7 @@
 
 (require 'eieio)
 (require 'nix)
+(require 'nix-log)
 (require 'magit-section)
 (eval-when-compile
   (require 'cl-lib))
@@ -209,19 +210,10 @@ It uses \\[nix-store-show-path] to display the store path."
 (defun nix-store-show-log ()
   "Opens the log file for the derivation of the nix-store path."
   (interactive)
-  (let ((drv-name (when-let*
-		      ((drv-name (nix-store-path-derivers nix-buffer-store-path))
-		       (drv-name (car drv-name)))
-		    (file-relative-name drv-name nix-store-dir))))
-    (if (not drv-name)
+  (let ((drv-path (car (nix-store-path-derivers nix-buffer-store-path))))
+    (if (not drv-path)
 	(message "This store path has no associated derivation.")
-      (let ((log-file (format "%s/log/nix/drvs/%s/%s.bz2"
-                              nix-state-dir
-                              (substring drv-name 0 2)
-			      (substring drv-name 2))))
-	(if (file-exists-p log-file)
-            (find-file log-file)
-	  (error "No log is available for derivation"))))))
+      (find-file (nix-log-path drv-path)))))
 
 (defvar nix-store-path-mode-map
   (let ((map (make-sparse-keymap)))

--- a/nix-store.el
+++ b/nix-store.el
@@ -206,6 +206,23 @@ It uses \\[nix-store-show-path] to display the store path."
   (interactive)
   (nix-store-show-path (nix-store-path-at-point)))
 
+(defun nix-store-show-log ()
+  "Opens the log file for the derivation of the nix-store path."
+  (interactive)
+  (let ((drv-name (when-let*
+		      ((drv-name (nix-store-path-derivers nix-buffer-store-path))
+		       (drv-name (car drv-name)))
+		    (file-relative-name drv-name nix-store-dir))))
+    (if (not drv-name)
+	(message "This store path has no associated derivation.")
+      (let ((log-file (format "%s/log/nix/drvs/%s/%s.bz2"
+                              nix-state-dir
+                              (substring drv-name 0 2)
+			      (substring drv-name 2))))
+	(if (file-exists-p log-file)
+            (find-file log-file)
+	  (error "No log is available for derivation"))))))
+
 (defvar nix-store-path-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "RET") 'nix-store-show-path-at-point)

--- a/nix-store.el
+++ b/nix-store.el
@@ -218,6 +218,7 @@ It uses \\[nix-store-show-path] to display the store path."
 (defvar nix-store-path-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "RET") 'nix-store-show-path-at-point)
+    (define-key map (kbd "l") 'nix-store-show-log)
     map))
 
 (defun nix-store--revert-buffer-function (&rest _ignore)


### PR DESCRIPTION
Firstly, thank you for such a useful mode!

I've found that the PRd function comes in handy when troubleshooting local nix derivations.

There are a couple of ways to find a corresponding log file. I chose this implementation purely because it was similar to the one used in `nix-log.el`.

Alternatively, we could use `nix log` and redirect the output to a buffer:

```elisp
(defun nix-store-show-log ()
  (interactive)
  (let* ((path (nix-store-path-path nix-buffer-store-path))
	 (buf (get-buffer-create (format "*Nix Log: %s*" path))))
    (shell-command (format "nix log %s" path) buf)
    (switch-to-buffer-other-window buf)))
```

What do you think? Is this worth adding to the mode?

I'm not quite sure how to test this, but am happy to add some if you have ideas.