### PR TITLE
Replace custom `nixfmt` wrapping with `reformatter`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
           f
           magit-section
           transient
+          reformatter
         ]);
       in stdenvNoCC.mkDerivation {
         pname = "nix-mode";

--- a/nix-format.el
+++ b/nix-format.el
@@ -3,54 +3,29 @@
 ;; This file is NOT part of GNU Emacs.
 
 ;; Homepage: https://github.com/NixOS/nix-mode
-;; Package-Requires: ((emacs "24.1"))
+;; Package-Requires: ((emacs "24.1") (reformatter "0.6"))
 ;; Version: 1.5.0
 
 ;;; Commentary:
 
 ;;; Code:
+(require 'reformatter)
 
 (defcustom nix-nixfmt-bin "nixfmt"
   "Path to nixfmt executable."
   :group 'nix
   :type 'string)
 
-(if (fboundp 'replace-buffer-contents)
-    (defun nix--replace-buffer-contents (src dst)
-      (with-current-buffer dst (replace-buffer-contents src)))
-  (defun nix--replace-buffer-contents (src dst)
-    (if (not (string= (with-current-buffer src (buffer-string))
-		      (with-current-buffer dst (buffer-string))))
-	(with-current-buffer src
-	  (copy-to-buffer dst (point-min) (point-max))))))
-
-(defun nix--format-call (buf nixfmt-bin)
-  "Format BUF using nixfmt."
-  (with-current-buffer (get-buffer-create "*nixfmt*")
-    (erase-buffer)
-    (insert-buffer-substring buf)
-    (if (zerop (call-process-region (point-min) (point-max) nixfmt-bin t t nil))
-	(nix--replace-buffer-contents (current-buffer) buf)
-      (error "Nixfmt failed, see *nixfmt* buffer for details"))))
-
-(defun nix--find-nixfmt ()
-  "Find the nixfmt binary, or error if it's missing."
-  (let ((nixfmt-bin (executable-find nix-nixfmt-bin)))
-    (unless nixfmt-bin
-      (error "Could not locate executable %S" nix-nixfmt-bin))
-    nixfmt-bin))
-
-(defun nix-format-buffer ()
-  "Format the current buffer using nixfmt."
-  (interactive)
-  (nix--format-call (current-buffer) (nix--find-nixfmt))
-  (message "Formatted buffer with nixfmt."))
-
-;;;###autoload
-(defun nix-format-before-save ()
-  "Add this to `before-save-hook' to run nixfmt when saving."
-  (when (derived-mode-p 'nix-mode)
-    (nix-format-buffer)))
+;;;###autoload (autoload 'nixfmt-buffer "nix-format")
+;;;###autoload (autoload 'nixfmt-region "nix-format")
+;;;###autoload (autoload 'nixfmt-on-save-mode "nix-format")
+(reformatter-define nixfmt
+  :program nix-nixfmt-bin
+  :args (list input-file)
+  :stdin nil
+  :stdout nil
+  :input-file (reformatter-temp-file-in-current-directory)
+  :group 'nix)
 
 (provide 'nix-format)
 ;;; nix-format.el ends here


### PR DESCRIPTION
`reformatter` here refers to https://github.com/purcell/emacs-reformatter.

Note that as currently written this PR _does_ remove existing user-facing commands. I would be glad to do any of the following:
1. Leave as-is and accept this as a breaking change.
1. Do not remove the old code and instead add the new functions in addition to the old one.
1. Create aliases from the new commands to the old ones. This would keep the code clean and avoid outright breaking the existing interface, but has a potential risk of the new functions behaving _slightly_ differently than the existing one.

For some related previous discussions, see
- https://github.com/NixOS/nix-mode/pull/120
- https://github.com/NixOS/nix-mode/pull/136
- https://github.com/NixOS/nix-mode/issues/152