### PR TITLE
Declare reformatter dependency in nix-mode.el

### DIFF
--- a/nix-mode.el
+++ b/nix-mode.el
@@ -4,7 +4,7 @@
 ;; Homepage: https://github.com/NixOS/nix-mode
 ;; Version: 1.5.0
 ;; Keywords: nix, languages, tools, unix
-;; Package-Requires: ((emacs "25.1") magit-section (transient "0.3"))
+;; Package-Requires: ((emacs "25.1") magit-section (transient "0.3") (reformatter "0.6"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
Since #176 nix-mode is broken for me. Only the dependencies in the main nix-mode.el file seem to be picked up, so this should fix it again.