### PR TITLE
Introduce `nix-store-path-omit-self`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Removed json-mode dependency, using js instead.
 * Compatibility with Emacs 28+.
-* Add nix-flake commands, based on magit-session.
+* Add nix-flake commands, based on magit-section.
 * Add nix-store-show-log command.
 * Other various fixes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased (1.6.0)
+
+* Introduce nix-store-path-omit-self customization option.
+
 ## 1.5.0
 
 * Removed json-mode dependency, using js instead.

--- a/nix-drv-mode.el
+++ b/nix-drv-mode.el
@@ -1,4 +1,4 @@
-;;; nix-drv-mode.el --- Major mode for viewing .drv files
+;;; nix-drv-mode.el --- Major mode for viewing .drv files -*- lexical-binding: t -*-
 
 ;; Maintainer: Matthew Bauer <mjbauer95@gmail.com>
 ;; Homepage: https://github.com/NixOS/nix-mode

--- a/nix-prettify-mode.el
+++ b/nix-prettify-mode.el
@@ -125,7 +125,7 @@ enabling/disabling `nix-prettify-mode'.  If nil, do nothing.")
   "Toggle Nix Prettify mode.
 
 With a prefix argument ARG, enable Nix Prettify mode if ARG is
-positive, and disable it otherwise.  If called from Lisp, enable
+positive, and disable it otherwise. If called from Lisp, enable
 the mode if ARG is omitted or nil.
 
 When Nix Prettify mode is enabled, hash-parts of the Nix store

--- a/nix-store.el
+++ b/nix-store.el
@@ -21,6 +21,10 @@
   "Nix-store customizations."
   :group 'nix)
 
+(defcustom nix-store-path-omit-self t
+  "Do not list the current entry itself within sections of nix-store-path-mode."
+  :package-version '(nix-mode . "1.6.0"))
+
 (defun nix-store-realise (path)
   "Realise a path asynchronously.
 PATH the path within /nix/store to realise"
@@ -112,7 +116,9 @@ information."
   "Helper macro for inserting a list as a magit-section.
 TYPE and VALUE will be used as the type and value of the section
 respectively. The LABEL is the text displayed."
-  `(let ((value ,value))
+  `(let ((value (cl-remove
+		 (and nix-store-path-omit-self (nix-store-path-path nix-buffer-store-path))
+		 ,value :test #'equal)))
      (when (and (listp value) (> (length value) 0))
        (magit-insert-section (,type value)
 	 (magit-insert-heading ,label)

--- a/nix-store.el
+++ b/nix-store.el
@@ -25,23 +25,23 @@
   "Realise a path asynchronously.
 PATH the path within /nix/store to realise"
   (make-process
-    :buffer nil
-    :command (list nix-store-executable "--realise" path)
-    :noquery t
-    :name (format "*nix-store*<%s>" path)))
+   :buffer nil
+   :command (list nix-store-executable "--realise" path)
+   :noquery t
+   :name (format "*nix-store*<%s>" path)))
 
 (defvar-local nix-buffer-store-path nil "Buffer-local object holding an `nix-store-path` object.")
 
 (defclass nix-store-path ()
-  ((path      :initarg :path          :accessor nix-store-path-path)
-    (status   :initarg :status        :accessor nix-store-path-status)
-    (hash     :initarg :hash          :accessor nix-store-path-hash)
-    (size     :initarg :size          :accessor nix-store-path-size)
-    (derivers :initarg :derivers      :accessor nix-store-path-derivers)
-    (outputs  :initarg :outputs       :accessor nix-store-path-outputs)
-    (references :initarg :references  :accessor nix-store-path-references)
-    (referrers  :initarg :referrers   :accessor nix-store-path-referrers)
-    (requisites :initarg :requisites  :accessor nix-store-path-requisites))
+  ((path       :initarg :path        :accessor nix-store-path-path)
+   (status     :initarg :status      :accessor nix-store-path-status)
+   (hash       :initarg :hash        :accessor nix-store-path-hash)
+   (size       :initarg :size        :accessor nix-store-path-size)
+   (derivers   :initarg :derivers    :accessor nix-store-path-derivers)
+   (outputs    :initarg :outputs     :accessor nix-store-path-outputs)
+   (references :initarg :references  :accessor nix-store-path-references)
+   (referrers  :initarg :referrers   :accessor nix-store-path-referrers)
+   (requisites :initarg :requisites  :accessor nix-store-path-requisites))
   "Nix-Store-Path Class holds all information of the path that
 is displayed")
 
@@ -65,30 +65,30 @@ being queried. Runs `nix-store-executable' to get that
 information."
   (let ((nix-executable nix-store-executable))
     (cond
-      ((eq 'deriver argument)
-	;; Special treatment for 'derivers', we want to treat a single entry
-	;; with this string as an empty list
-	(remove "unknown-deriver"
-	  (nix--process-lines "--query" "--deriver" path )))
-      ((eq 'size argument) (string-to-number (nix--process-string "--query" "--size" path )))
-      ((eq 'hash argument) (nix--process-string "--query" "--hash" path ))
-      ((eq 'requisites argument) (nix--process-lines "--query" "--requisites" path ))
-      ((eq 'references argument) (nix--process-lines "--query" "--references" path ))
-      ((eq 'referrers argument) (nix--process-lines "--query" "--referrers" path ))
-      ((eq 'outputs argument)
-	(ignore-errors
-	  ;; This can fail for non-derivation paths
-	  (nix--process-lines "--query" "--outputs" path )))
-      (t (error "Unknown argument to nix-store --query: %s" argument)))))
+     ((eq 'deriver argument)
+      ;; Special treatment for 'derivers', we want to treat a single entry
+      ;; with this string as an empty list
+      (remove "unknown-deriver"
+	      (nix--process-lines "--query" "--deriver" path )))
+     ((eq 'size argument) (string-to-number (nix--process-string "--query" "--size" path )))
+     ((eq 'hash argument) (nix--process-string "--query" "--hash" path ))
+     ((eq 'requisites argument) (nix--process-lines "--query" "--requisites" path ))
+     ((eq 'references argument) (nix--process-lines "--query" "--references" path ))
+     ((eq 'referrers argument) (nix--process-lines "--query" "--referrers" path ))
+     ((eq 'outputs argument)
+      (ignore-errors
+	;; This can fail for non-derivation paths
+	(nix--process-lines "--query" "--outputs" path )))
+     (t (error "Unknown argument to nix-store --query: %s" argument)))))
 
 (cl-defun nix-store-path-insert-path (&optional (store-path nix-buffer-store-path))
   "Insert a section showing the path of STORE-PATH."
   (magit-insert-section (path (nix-store-path-path store-path))
     (magit-insert-heading (propertize (format "%-11s" "Path:") 'face 'magit-section-heading)
       (propertize (oref store-path path)
-	'face (if (file-exists-p (nix-store-path-path store-path))
-		'nix-store-path-realised-face
-		'nix-store-path-unrealised-face) ))))
+		  'face (if (file-exists-p (nix-store-path-path store-path))
+			    'nix-store-path-realised-face
+			  'nix-store-path-unrealised-face) ))))
 
 (cl-defun nix-store-path-insert-size (&optional (store-path nix-buffer-store-path))
   "Insert a section showing the size of STORE-PATH."
@@ -117,12 +117,12 @@ respectively. The LABEL is the text displayed."
        (magit-insert-section (,type value)
 	 (magit-insert-heading ,label)
 	 (cl-loop for x in value
-	   for exists = (file-exists-p x)
-	   do
-	   (magit-insert-section (store-path x)
-	     (insert
-	       (propertize x 'face (if exists 'nix-store-path-realised-face 'nix-store-path-unrealised-face))
-	       ?\n)))
+		  for exists = (file-exists-p x)
+		  do
+		  (magit-insert-section (store-path x)
+		    (insert
+		     (propertize x 'face (if exists 'nix-store-path-realised-face 'nix-store-path-unrealised-face))
+		     ?\n)))
 	 (insert ?\n)
 	 (magit-insert-child-count (magit-current-section))))))
 
@@ -148,24 +148,24 @@ respectively. The LABEL is the text displayed."
 
 (defcustom nix-store-path-headers-hook
   '(nix-store-path-insert-path
-     nix-store-path-insert-status
-     nix-store-path-insert-hash
-     nix-store-path-insert-size)
+    nix-store-path-insert-status
+    nix-store-path-insert-hash
+    nix-store-path-insert-size)
   "Hook run to insert headers into the nix-store buffer.
 A list of function that each take one argument, the store path object."
   :group 'nix-store
   :type 'hook
   :options '(nix-store-path-insert-path
-	      nix-store-path-insert-status
-	      nix-store-path-insert-hash
-	      nix-store-path-insert-size))
+	     nix-store-path-insert-status
+	     nix-store-path-insert-hash
+	     nix-store-path-insert-size))
 
 (defcustom nix-store-path-sections-hook
   '(nix-store-path-insert-derivers
-     nix-store-path-insert-outputs
-     nix-store-path-insert-references
-     nix-store-path-insert-referrers
-     nix-store-path-insert-requisites)
+    nix-store-path-insert-outputs
+    nix-store-path-insert-references
+    nix-store-path-insert-referrers
+    nix-store-path-insert-requisites)
   "Hook run to insert sections into a nix-store buffer.
 A list of function that each take one argument, the store path object."
   :group 'nix-store
@@ -183,7 +183,7 @@ implement your own ones) you can customize the variable
   (switch-to-buffer (format "Nix Store Path: %s" path))
   (nix-store-path-mode)
   (setq nix-buffer-store-path (nix-store-fill-data (make-instance 'nix-store-path :path path))
-    list-buffers-directory path)
+	list-buffers-directory path)
   (when (file-directory-p path)
     (setq default-directory path))
   (let ((inhibit-read-only t))

--- a/nix-store.el
+++ b/nix-store.el
@@ -124,11 +124,10 @@ respectively. The LABEL is the text displayed."
 	 (magit-insert-heading ,label)
 	 (cl-loop for x in value
 		  for exists = (file-exists-p x)
+		  for face = (if exists 'nix-store-path-realised-face 'nix-store-path-unrealised-face)
 		  do
 		  (magit-insert-section (store-path x)
-		    (insert
-		     (propertize x 'face (if exists 'nix-store-path-realised-face 'nix-store-path-unrealised-face))
-		     ?\n)))
+		    (insert (propertize x 'face face) ?\n)))
 	 (insert ?\n)
 	 (magit-insert-child-count (magit-current-section))))))
 
@@ -161,6 +160,7 @@ respectively. The LABEL is the text displayed."
 A list of function that each take one argument, the store path object."
   :group 'nix-store
   :type 'hook
+  :package-version '(nix-mode . "1.5.0")
   :options '(nix-store-path-insert-path
 	     nix-store-path-insert-status
 	     nix-store-path-insert-hash
@@ -175,7 +175,8 @@ A list of function that each take one argument, the store path object."
   "Hook run to insert sections into a nix-store buffer.
 A list of function that each take one argument, the store path object."
   :group 'nix-store
-  :type 'hook)
+  :type 'hook
+  :package-version '(nix-mode . "1.5.0"))
 
 (defun nix-store-show-path (path)
   "Show a nix-store PATH.
@@ -214,10 +215,9 @@ It uses \\[nix-store-show-path] to display the store path."
 (defun nix-store-show-log ()
   "Opens the log file for the derivation of the nix-store path."
   (interactive)
-  (let ((drv-path (car (nix-store-path-derivers nix-buffer-store-path))))
-    (if (not drv-path)
-	(message "This store path has no associated derivation.")
-      (find-file (nix-log-path drv-path)))))
+  (if-let ((drv-path (car (nix-store-path-derivers nix-buffer-store-path))))
+      (find-file (nix-log-path drv-path))
+    (user-error "This store path has no associated derivation.")))
 
 (defvar nix-store-path-mode-map
   (let ((map (make-sparse-keymap)))
@@ -230,6 +230,7 @@ It uses \\[nix-store-show-path] to display the store path."
   (nix-store-show-path (nix-store-path-path nix-buffer-store-path)))
 
 (define-derived-mode nix-store-path-mode magit-section-mode "Nix Store Path"
+  :group 'nix-store
   (setq-local revert-buffer-function #'nix-store--revert-buffer-function)
   (read-only-mode 1))
 


### PR DESCRIPTION
It can sometimes be considered useless information if, for example, a store path lists itself within the requisites or output section. This customization option is supposed to help with removing this unintended behavior.