### PR TITLE
nix-flake: set default major-mode of flake.lock to js-mode

### DIFF
--- a/nix-flake.el
+++ b/nix-flake.el
@@ -570,5 +570,8 @@ See `nix-flake-init-post-action' variable for details."
         (user-error "The directory already contains a flake")
       (nix-flake-init-dispatch))))
 
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\flake.lock\\'" . js-mode))
+
 (provide 'nix-flake)
 ;;; nix-flake.el ends here


### PR DESCRIPTION
for benefits such as syntax highlighting

cc @matthewbauer 