### PR TITLE
add missing Package-Requires declaration in nix-store.el header

### DIFF
--- a/nix-store.el
+++ b/nix-store.el
@@ -3,7 +3,7 @@
 ;; Author: Matthew Bauer <mjbauer95@gmail.com>
 ;; Homepage: https://github.com/NixOS/nix-mode
 ;; Keywords: nix
-;; Package-Requires: ((magit-section "3.0.0"))
+;; Package-Requires: ((magit-section))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/nix-store.el
+++ b/nix-store.el
@@ -3,6 +3,7 @@
 ;; Author: Matthew Bauer <mjbauer95@gmail.com>
 ;; Homepage: https://github.com/NixOS/nix-mode
 ;; Keywords: nix
+;; Package-Requires: ((magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
This is needed by users who rely on **emacs** rather than **nix** to install the required dependencies to `nix-store.el`