### PR TITLE
Check Man-header-file-path is a list or not for emacs31.1

### DIFF
--- a/nix-shell.el
+++ b/nix-shell.el
@@ -193,8 +193,9 @@ The DRV file to use."
 		      (format "%s:%s" bin eshell-path-env))
       (when (boundp 'woman-manpath)
 	    (add-to-list 'woman-manpath man))
-	  (add-to-list 'ffap-c-path include)
-	  (add-to-list 'Man-header-file-path include)
+      (add-to-list 'ffap-c-path include)
+      (when (listp Man-header-file-path)
+	(add-to-list 'Man-header-file-path include))
       (when (boundp 'irony-additional-clang-options)
 	    (add-to-list 'irony-additional-clang-options
 		       (format "-I%s" include)))))


### PR DESCRIPTION
In emacs 31.1, its type is changed as following:

```
:type '(choice (repeat string) (const :tag "Use 'ffap-c-path'" t)))
```

And its default value is t instead of nil or a list.