### PR TITLE
feat: better json fontification with json-ts-mode, fix: handles stderr in nix-drv-mode

### DIFF
--- a/nix-drv-mode.el
+++ b/nix-drv-mode.el
@@ -20,15 +20,35 @@
 ;;;###autoload
 (define-derived-mode nix-drv-mode json-ts-mode "Nix-Derivation"
   "Pretty print Nix’s .drv files."
-  (let ((inhibit-read-only t))
-    (erase-buffer)
-    (insert (shell-command-to-string
-             (format "%s show-derivation \"%s\""
-		     nix-executable
-		     (buffer-file-name))))
-    (set-buffer-modified-p nil)
-    (read-only-mode 1))
-
+  (setq inhibit-read-only t)
+  (erase-buffer)
+  (let ((err-buf (generate-new-buffer "*nix-drv-mode*")))
+    (make-process
+     :name "nix-drv-mode"
+     :buffer (current-buffer)
+     :command (list nix-executable "derivation" "show" (buffer-file-name))
+     :stderr err-buf
+     :sentinel (lambda (proc event)
+		 (setq inhibit-read-only nil)
+		 (when (string-match "finished" event)
+		   (let ((buf (process-buffer proc)))
+                     (when (and buf (buffer-live-p buf))
+                       (with-current-buffer buf
+			 (set-buffer-modified-p nil)
+			 (read-only-mode)
+			 )))
+		   (when (and (buffer-live-p err-buf) (> (buffer-size err-buf) 0))
+		     (with-current-buffer err-buf
+		       (read-only-mode))
+		     (display-buffer err-buf))
+		   ))
+     :filter (lambda (proc output)
+               ;; use process buffer for output
+               (let ((buf (process-buffer proc)))
+		 (when (and buf (buffer-live-p buf))
+		   (with-current-buffer buf
+                     (goto-char (point-max))
+                     (insert output)))))))
   (add-hook 'change-major-mode-hook #'nix-drv-mode-dejsonify-buffer nil t))
 
 (defun nix-drv-mode-dejsonify-buffer ()

--- a/nix-drv-mode.el
+++ b/nix-drv-mode.el
@@ -18,7 +18,7 @@
 (require 'nix)
 
 ;;;###autoload
-(define-derived-mode nix-drv-mode js-mode "Nix-Derivation"
+(define-derived-mode nix-drv-mode json-ts-mode "Nix-Derivation"
   "Pretty print Nix’s .drv files."
   (let ((inhibit-read-only t))
     (erase-buffer)

--- a/nix-flake.el
+++ b/nix-flake.el
@@ -571,7 +571,7 @@ See `nix-flake-init-post-action' variable for details."
       (nix-flake-init-dispatch))))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\flake.lock\\'" . js-mode))
+(add-to-list 'auto-mode-alist '("\\flake.lock\\'" . json-ts-mode))
 
 (provide 'nix-flake)
 ;;; nix-flake.el ends here


### PR DESCRIPTION
2 commits:
- 81e735f2c273da4758a273cd4ed3f40ade0aa72e
  - feat: better json fontification with json-ts-mode
  - replacing `js-mode` with `json-ts-mode`
    - [part of Emacs core since Emacs 29](https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/progmodes/json-ts-mode.el?h=emacs-29.0.90)
    - [Github mirror](https://github.com/emacs-mirror/emacs/blob/emacs-29.0.90/lisp/progmodes/json-ts-mode.el)
- 891d9632e4b116760495d803bfa35b80803ce586
  - fix: handles stderr in nix-drv-mode
  - `nix-drv-mode` behaves weirdly when things got printed to stderr, which
is common when nix warns about feature deprecation
replacing `shell-command-to-string` with `make-process` allows us to ignoring stderr