### PR TITLE
nixfmt: Switch to reformatter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,37 +3,57 @@
 
   inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
 
-  outputs = { self, nixpkgs }: let
-    systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
-    forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
-  in {
-    packages = forAllSystems (system: with (import nixpkgs { inherit system; }); {
-      default = let
-        emacs = emacsWithPackages (epkgs: with epkgs; [
-          org-contrib
-          company
-          mmm-mode
-          magit-section
-          transient
-        ]);
-      in stdenv.mkDerivation {
-        pname = "nix-mode";
-        version = "1.5.0";
-        src = self;
-        nativeBuildInputs = [ emacs texinfo git ];
-        makeFlags = [ "PREFIX=$(out)" ];
-        shellHook = ''
-          echo Run make run to get vanilla emacs with nix-mode loaded.
-        '';
-        doCheck = true;
-        meta.description = "An emacs major mode for editing Nix expressions";
-      };
-    });
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "i686-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+    in
+    {
+      packages = forAllSystems (
+        system: with (import nixpkgs { inherit system; }); {
+          default =
+            let
+              emacs = emacsWithPackages (
+                epkgs: with epkgs; [
+                  org-contrib
+                  company
+                  mmm-mode
+                  magit-section
+                  transient
+                  reformatter
+                ]
+              );
+            in
+            stdenv.mkDerivation {
+              pname = "nix-mode";
+              version = "1.5.0";
+              src = self;
+              nativeBuildInputs = [
+                emacs
+                texinfo
+                git
+              ];
+              makeFlags = [ "PREFIX=$(out)" ];
+              shellHook = ''
+                echo Run make run to get vanilla emacs with nix-mode loaded.
+              '';
+              doCheck = true;
+              meta.description = "An emacs major mode for editing Nix expressions";
+            };
+        }
+      );
 
-    # checks are run in ‘make check’ right now we should probably move
-    # these to its own derivation
-    checks = forAllSystems (system: {
-      inherit (self.packages.${system}) default;
-    });
-  };
+      # checks are run in ‘make check’ right now we should probably move
+      # these to its own derivation
+      checks = forAllSystems (system: {
+        inherit (self.packages.${system}) default;
+      });
+    };
 }

--- a/nix-format.el
+++ b/nix-format.el
@@ -6,48 +6,31 @@
 
 ;;; Commentary:
 
+;; Uses reformatter to define nix-format-buffer and
+;; nix-format-on-save-mode.
+
 ;;; Code:
 
+(require 'reformatter)
+
 (defcustom nix-nixfmt-bin "nixfmt"
-  "Path to nixfmt executable."
-  :group 'nix
-  :type 'string)
+	"Path to nixfmt executable."
+	:group 'nix
+	:type 'string)
 
-(defun nix--replace-buffer-contents (src dst)
-  (if (fboundp 'replace-buffer-contents)
-      (with-current-buffer dst (replace-buffer-contents src))
-    (unless  (string= (with-current-buffer src (buffer-string))
-		      (with-current-buffer dst (buffer-string)))
-      (with-current-buffer src
-	(copy-to-buffer dst (point-min) (point-max))))))
+(defcustom nix-nixfmt-args '("-")
+	"Command-line arguments for nixfmt."
+	:group 'nix
+	:type '(repeat string))
 
-(defun nix--format-call (buf nixfmt-bin)
-  "Format BUF using nixfmt."
-  (with-current-buffer (get-buffer-create "*nixfmt*")
-    (erase-buffer)
-    (insert-buffer-substring buf)
-    (if (zerop (call-process-region (point-min) (point-max) nixfmt-bin t t nil))
-	(nix--replace-buffer-contents (current-buffer) buf)
-      (error "Nixfmt failed, see *nixfmt* buffer for details"))))
-
-(defun nix--find-nixfmt ()
-  "Find the nixfmt binary, or error if it's missing."
-  (let ((nixfmt-bin (executable-find nix-nixfmt-bin)))
-    (unless nixfmt-bin
-      (error "Could not locate executable %S" nix-nixfmt-bin))
-    nixfmt-bin))
-
-(defun nix-format-buffer ()
-  "Format the current buffer using nixfmt."
-  (interactive)
-  (nix--format-call (current-buffer) (nix--find-nixfmt))
-  (message "Formatted buffer with nixfmt."))
-
-;;;###autoload
-(defun nix-format-before-save ()
-  "Add this to `before-save-hook' to run nixfmt when saving."
-  (when (derived-mode-p 'nix-mode)
-    (nix-format-buffer)))
+;;;###autoload (autoload 'nix-format-buffer "nix-format" nil t)
+;;;###autoload (autoload 'nix-format-region "nix-format" nil t)
+;;;###autoload (autoload 'nix-format-on-save-mode "nix-format" nil t)
+(reformatter-define nix-format
+	:program nix-nixfmt-bin
+	:args nix-nixfmt-args
+	:group 'nix
+	:lighter " nixfmt")
 
 (provide 'nix-format)
 ;;; nix-format.el ends here

--- a/nix-mode.el
+++ b/nix-mode.el
@@ -4,7 +4,7 @@
 ;; Homepage: https://github.com/NixOS/nix-mode
 ;; Version: 1.5.0
 ;; Keywords: nix, languages, tools, unix
-;; Package-Requires: ((emacs "25.1") magit-section (transient "0.3"))
+;; Package-Requires: ((emacs "25.1") magit-section reformatter (transient "0.3"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
This is stale. I'm switching to relying on reformatter now.

---

This does 3 things in 2 changes,
- Program calling improvements,
  - Adds a way to customise the arguments to nixfmt.
  - Upgrades how `nixfmt` is called to avoid a warning about `stdin` no longer being implicitly processed.
- Program output handling,
  - Splits the stdout/stderr outputs so errors no longer corrupt the user's formatted buffer.

I tested this locally and it no longer run into https://github.com/NixOS/nix-mode/issues/210


NOTE: I vibe-coded the changes with opencode, but they seem sensible (although I can see how the building of arguments may have a nicer way of writing in elisp)